### PR TITLE
Treat SQL null as null when result set mapping

### DIFF
--- a/src/main/java/me/shakiba/jdbi/annotation/AnnoMapper.java
+++ b/src/main/java/me/shakiba/jdbi/annotation/AnnoMapper.java
@@ -62,25 +62,36 @@ public class AnnoMapper<C> implements ResultSetMapper<C> {
             throws SQLException {
         Type type = annoMember.getType();
         String name = annoMember.getName();
+        Object value;
         switch (type) {
         case String:
-            return rs.getString(name);
-        case Long:
-            return rs.getLong(name);
-        case Int:
-            return rs.getInt(name);
-        case Double:
-            return rs.getDouble(name);
-        case Float:
-            return rs.getFloat(name);
-        case Boolean:
-            return rs.getBoolean(name);
-        case Date:
-            return rs.getDate(name);
-        default:
+            value = rs.getString(name);
             break;
+        case Long:
+            value = rs.getLong(name);
+            break;
+        case Int:
+            value = rs.getInt(name);
+            break;
+        case Double:
+            value = rs.getDouble(name);
+            break;
+        case Float:
+            value = rs.getFloat(name);
+            break;
+        case Boolean:
+            value = rs.getBoolean(name);
+            break;
+        case Date:
+            value = rs.getDate(name);
+            break;
+        default:
+            return null;
         }
-        return null;
+        if (rs.wasNull()) {
+            return null;
+        }
+        return value;
     }
 
     private static Logger logger = LoggerFactory.getLogger(AnnoMapper.class);

--- a/src/test/java/me/shakiba/jdbi/annotation/AnnoTest.java
+++ b/src/test/java/me/shakiba/jdbi/annotation/AnnoTest.java
@@ -11,12 +11,12 @@ import org.testng.annotations.Test;
 public class AnnoTest extends Assert {
 
     public void test() throws Exception {
-        Something brian = new Something(1, "Brian");
-        Something keith = new Something(2, "Keith");
+        Something brian = new Something(1, "Brian", null);
+        Something keith = new Something(2, "Keith", 7777777777777L);
 
         DBI dbi = new DBI("jdbc:h2:mem:test");
         Handle h = dbi.open();
-        h.execute("create table something (id int primary key, name varchar(100))");
+        h.execute("create table something (id int primary key, name varchar(100), value bigint)");
 
         SomethingDAO dao = dbi.open(SomethingDAO.class);
         dao.insert(brian);
@@ -37,5 +37,6 @@ public class AnnoTest extends Assert {
     static public void assertEquals(Something actual, Something expected) {
         assertEquals(actual.id(), expected.id());
         assertEquals(actual.name(), expected.name());
+        assertEquals(actual.value, expected.value);
     }
 }

--- a/src/test/java/me/shakiba/jdbi/annotation/Something.java
+++ b/src/test/java/me/shakiba/jdbi/annotation/Something.java
@@ -8,13 +8,17 @@ public class Something extends Somesuper {
     @Column
     private String name;
 
+    @Column
+    public Long value;
+
     @SuppressWarnings("unused")
     private Something() {
     }
 
-    public Something(int id, String name) {
+    public Something(int id, String name, Long value) {
         super(id);
         this.name = name;
+        this.value = value;
     }
 
     public String name() {

--- a/src/test/java/me/shakiba/jdbi/annotation/SomethingDAO.java
+++ b/src/test/java/me/shakiba/jdbi/annotation/SomethingDAO.java
@@ -6,7 +6,7 @@ import org.skife.jdbi.v2.sqlobject.customizers.RegisterMapperFactory;
 @RegisterMapperFactory(AnnoMapperFactory.class)
 public interface SomethingDAO {
 
-    @SqlUpdate("insert into something (id, name) values (:id, :name)")
+    @SqlUpdate("insert into something (id, name, value) values (:id, :name, :value)")
     void insert(@BindAnno Something something);
 
 }


### PR DESCRIPTION
Currently a null integer column maps to 0 rather than null making it impossible to distinguish SQL nulls. This change maps SQL null to Java null in AnnoMapper.get() which actually just means the setter is never called by AnnoMember.write().

Note that this is potentially a breaking change if someone relied on the null to 0 mapping behaviour.

I used a public field rather than getter and setter methods for the "value" column in the test so we get some test coverage of both access styles.
